### PR TITLE
Remove redundant std::move

### DIFF
--- a/src/date_time.cc
+++ b/src/date_time.cc
@@ -66,7 +66,7 @@ time_duration parse_offset(std::string const& offset_str) {
   if (m[2].length() > 0) {
     offset += minutes(std::stoi(m[2]));
   }
-  return std::move(offset);
+  return offset;
 }
 
 std::time_t parse_date_time(std::string const& str) {


### PR DESCRIPTION
This came up as a warning when building a project with conf as dependency